### PR TITLE
Fix #N/A appearing on agency number widgets

### DIFF
--- a/jobs/org_status.rb
+++ b/jobs/org_status.rb
@@ -7,7 +7,7 @@ def fetch_with_retry(cell)
   begin
     value = XmlSimple.xml_in(RestClient.get("#{SPREADSHEET_ROOT}/#{cell}"))['content']['content']
     sleep(2)
-  end until value != '#N/A' && done != '#VALUE!'
+  end until value != '#N/A' && value != '#VALUE!'
   value
 end
 

--- a/jobs/org_status.rb
+++ b/jobs/org_status.rb
@@ -4,8 +4,12 @@ require 'xmlsimple'
 SPREADSHEET_ROOT = "https://spreadsheets.google.com/feeds/cells/#{ENV['main_spreadsheet_key']}/od6/public/values"
 
 SCHEDULER.every '15m', :first_in => 0 do |job|
-  done = XmlSimple.xml_in(RestClient.get("#{SPREADSHEET_ROOT}/R1C6"))['content']['content']
-  todo = XmlSimple.xml_in(RestClient.get("#{SPREADSHEET_ROOT}/R1C8"))['content']['content']
+  begin
+    done = XmlSimple.xml_in(RestClient.get("#{SPREADSHEET_ROOT}/R1C6"))['content']['content']
+    todo = XmlSimple.xml_in(RestClient.get("#{SPREADSHEET_ROOT}/R1C8"))['content']['content']
+    sleep(2)
+  end until done != '#N/A' && done != '#VALUE!' && todo != "#N/A" && todo != '#VALUE!'
+
   send_event('orgs_done', { done: done })
   send_event('orgs_todo', { todo: todo })
 end

--- a/jobs/org_status.rb
+++ b/jobs/org_status.rb
@@ -1,11 +1,11 @@
 require 'rest_client'
 require 'xmlsimple'
 
-spreadsheet_root = "https://spreadsheets.google.com/feeds/cells/#{ENV['main_spreadsheet_key']}"
+SPREADSHEET_ROOT = "https://spreadsheets.google.com/feeds/cells/#{ENV['main_spreadsheet_key']}/od6/public/values"
 
 SCHEDULER.every '15m', :first_in => 0 do |job|
-  done = XmlSimple.xml_in(RestClient.get("#{spreadsheet_root}/od6/public/values/R1C6"))['content']['content']
-  todo = XmlSimple.xml_in(RestClient.get("#{spreadsheet_root}/od6/public/values/R1C8"))['content']['content']
+  done = XmlSimple.xml_in(RestClient.get("#{SPREADSHEET_ROOT}/R1C6"))['content']['content']
+  todo = XmlSimple.xml_in(RestClient.get("#{SPREADSHEET_ROOT}/R1C8"))['content']['content']
   send_event('orgs_done', { done: done })
   send_event('orgs_todo', { todo: todo })
 end


### PR DESCRIPTION
- This was caused by Google Spreadsheets running the command to import data from the transition spreadsheet and not getting data. This made `#N/A` appear for unpredictable lengths of time, unpredictably, so this hopefully successfully deals with it by querying the spreadsheet every two seconds until the todo and done values are no longer `#N/A`, or another variant `#VALUE!`.
- Do some tidying up to make `SPREADSHEET_ROOT` a constant and include the worksheet key in it, while I'm here.
