### PR TITLE
Add burndown training graph as a widget to the second dashboard

### DIFF
--- a/dashboards/second.erb
+++ b/dashboards/second.erb
@@ -1,5 +1,8 @@
 <% content_for :title do %>Transition Manager Dashboard<% end %>
 <div class="gridster">
   <ul>
+    <li data-row="1" data-sizex="4" data-sizey="2">
+      <div data-id="burndown_chart" data-view="Graph"></div>
+    </li>
   </ul>
 </div>

--- a/dashboards/second.erb
+++ b/dashboards/second.erb
@@ -2,7 +2,7 @@
 <div class="gridster">
   <ul>
     <li data-row="1" data-sizex="4" data-sizey="2">
-      <div data-id="burndown_chart" data-view="Graph"></div>
+      <div data-id="burndown_chart" data-view="Graph" data-title="Expected (black) vs. actual (white) number of users trained by month"></div>
     </li>
   </ul>
 </div>

--- a/dashboards/second.erb
+++ b/dashboards/second.erb
@@ -1,0 +1,5 @@
+<% content_for :title do %>Transition Manager Dashboard<% end %>
+<div class="gridster">
+  <ul>
+  </ul>
+</div>

--- a/jobs/burndown_chart.rb
+++ b/jobs/burndown_chart.rb
@@ -7,15 +7,14 @@ def graph_points(type)
   # There are twenty-eight rows in the spreadsheet.
   (0..27).each do
     # Format of method params: Worksheet, Row, Column.
-    dates.push({ x: SpreadsheetData.content(2, row, 1) })
-    actual_training.push({ y: SpreadsheetData.content(2, row, 2) })
-    expected_training.push({ y: SpreadsheetData.content(2, row, 3) })
+    # Convert the date to epoch time with .to_i.
+    dates.push({ x: SpreadsheetData.content(2, row, 1).to_i })
+    actual_training.push({ y: SpreadsheetData.content(2, row, 2).to_i })
+    expected_training.push({ y: SpreadsheetData.content(2, row, 3).to_i })
     row += 1
   end
 
-  # Condense the two hashes into actual or expected arrays of hashes
-  # of the form:
-  # [{:x=>"1/26/2014", :y=>"800"}]
+  # Condense the two hashes into actual or expected arrays of hashes.
   if type == 'actual'
     return dates.zip(actual_training).collect { |array| array.inject(:merge) }
   elsif type == 'expected'

--- a/jobs/burndown_chart.rb
+++ b/jobs/burndown_chart.rb
@@ -1,0 +1,32 @@
+require 'rest_client'
+require 'xmlsimple'
+
+def graph_points
+  graph_points = []
+  worksheet = 2
+  row = 2
+  column = 1
+  dates = []
+  actual_numbers = []
+
+  # There are twenty-eight rows in the spreadsheet.
+  (0..27).each do
+    dates.push(SpreadsheetData.content(worksheet, row, column))
+    actual_numbers.push(SpreadsheetData.content(worksheet, row, (column += 1)))
+    column = 1 # For each iteration of row, reset the column count.
+    row += 1
+  end
+
+  dates.each do |date|
+    graph_points << { x: date }
+  end
+  actual_numbers.each do |number|
+    graph_points << { y: number }
+  end
+  puts graph_points.inspect
+  graph_points
+end
+
+SCHEDULER.every '2h', :first_in => 0 do |job|
+  send_event('burndown_chart', { points: graph_points })
+end

--- a/lib/spreadsheet_data.rb
+++ b/lib/spreadsheet_data.rb
@@ -8,6 +8,15 @@ class SpreadsheetData
     begin
       response = RestClient.get("#{SPREADSHEET_URL}/#{worksheet}/public/values/R#{row}C#{column}")
       parsed = XmlSimple.xml_in(response)['content']['content']
+      if parsed.include?('/')
+        # Assume it is a date of the form mm/dd/yyyy, rearrange it to
+        # yyyymmdd and treat it like a time.
+        parsed_split = parsed.split('/')
+        parsed = Date.new(parsed_split[2].to_i,
+                          parsed_split[0].to_i,
+                          parsed_split[1].to_i
+                         ).to_time
+      end
       sleep(2)
     end until parsed != '#N/A' && parsed != '#VALUE!'
     parsed

--- a/widgets/graph/graph.coffee
+++ b/widgets/graph/graph.coffee
@@ -2,35 +2,38 @@ class Dashing.Graph extends Dashing.Widget
 
   @accessor 'current', ->
     return @get('displayedValue') if @get('displayedValue')
-    points = @get('points')
-    if points
-      points[points.length - 1].y
 
   ready: ->
     container = $(@node).parent()
-    # Gross hacks. Let's fix this.
     width = (Dashing.widget_base_dimensions[0] * container.data("sizex")) + Dashing.widget_margins[0] * 2 * (container.data("sizex") - 1)
     height = (Dashing.widget_base_dimensions[1] * container.data("sizey"))
     @graph = new Rickshaw.Graph(
       element: @node
       width: width
       height: height
-      renderer: @get("graphtype")
+      renderer: 'line'
       series: [
         {
-        color: "#fff",
-        data: [{x:0, y:0}]
+          color: "#fff",
+          data: [{x:0, y:0}]
+        },
+        {
+          color: "#222",
+          data: [{x:0, y:0}]
         }
       ]
     )
 
-    @graph.series[0].data = @get('points') if @get('points')
+    @graph.series[0].data = @get('actual') if @get('actual')
+    @graph.series[1].data = @get('expected') if @get('expected')
 
     x_axis = new Rickshaw.Graph.Axis.Time(graph: @graph)
     y_axis = new Rickshaw.Graph.Axis.Y(graph: @graph, tickFormat: Rickshaw.Fixtures.Number.formatKMBT)
+    @graph.renderer.unstack = true
     @graph.render()
 
   onData: (data) ->
     if @graph
-      @graph.series[0].data = data.points
+      @graph.series[0].data[0] = data.points[0][0]
+      @graph.series[1].data[1] = data.points[1][1]
       @graph.render()

--- a/widgets/graph/graph.scss
+++ b/widgets/graph/graph.scss
@@ -5,7 +5,7 @@ $background-color:  #dc5945;
 
 $title-color:       rgba(255, 255, 255, 0.7);
 $moreinfo-color:    rgba(255, 255, 255, 0.3);
-$tick-color:        rgba(0, 0, 0, 0.4);
+$tick-color:        rgba(0, 0, 0, 0.5);
 
 
 // ----------------------------------------------------------------------------
@@ -19,8 +19,8 @@ $tick-color:        rgba(0, 0, 0, 0.4);
 
   svg {
     position: absolute;
-    opacity: 0.4;
-    fill-opacity: 0.4;
+    opacity: 5;
+    fill-opacity: 5;
     left: 0px;
     top: 0px;
   }
@@ -47,13 +47,15 @@ $tick-color:        rgba(0, 0, 0, 0.4);
     .title {
       font-size: 20px;
       color: $tick-color;
-      opacity: 0.5;
+      fill: $tick-color;
+      fill-opacity: 1;
       padding-bottom: 3px;
     }
   }
 
   .y_ticks {
     font-size: 20px;
+    color: $tick-color;
     fill: $tick-color;
     fill-opacity: 1;
   }

--- a/widgets/graph/graph.scss
+++ b/widgets/graph/graph.scss
@@ -31,6 +31,7 @@ $tick-color:        rgba(0, 0, 0, 0.5);
   }
 
   .title {
+    padding-bottom: 700px;
     color: $title-color;
   }
 


### PR DESCRIPTION
**Please do not merge yet.**
- Split this new graph into another dashboard.
- Retrieve data from a Google Spreadsheet for the burndown statistics.
- Make a graph out of this data.
- Style the graph widget.

I still need to work out how to make the key for the lines display, and possibly make the lines slightly thicker again so they're more readable. There's also a slight CSS problem where the August month on the x axis creeps over the edge of the dashboard widget - can I request that @fofr possibly take a look? This is just about visible in this screenshot:
![screen shot 2014-05-13 at 15 13 15](https://cloud.githubusercontent.com/assets/355033/2958350/c59921bc-daa8-11e3-8ce5-fdf8760f26db.png)

Are the colours of the lines and the background OK? I just used the defaults.
